### PR TITLE
Use http://example.org/foo/bar as base URL in CLI

### DIFF
--- a/src/main/java/io/mola/galimatias/cli/CLI.java
+++ b/src/main/java/io/mola/galimatias/cli/CLI.java
@@ -107,10 +107,17 @@ public class CLI {
 
         boolean parseErrors;
 
+        URL base = null;
+        try {
+            base = URL.parse("http://example.org/foo/bar");
+        } catch (GalimatiasParseException ex) {
+            assert false; // shouldn't get in here unless serious bug
+        }
+
         try {
             System.out.println("Parsing with WHATWG rules...");
             settings = settings.withStandard(URLParsingSettings.Standard.WHATWG);
-            url = URL.parse(settings, input);
+            url = URL.parse(settings, base, input);
             whatwgUrlSerialized = url.toString();
             printResult(url);
         } catch (GalimatiasParseException ex) {
@@ -121,7 +128,7 @@ public class CLI {
         try {
             System.out.println("Parsing with RFC 3986 rules...");
             settings = settings.withStandard(URLParsingSettings.Standard.RFC_3986);
-            url = URL.parse(settings, input);
+            url = URL.parse(settings, base, input);
             rfc3986UrlSerialized = url.toString();
             if (whatwgUrlSerialized.equals(url.toString())) {
                 System.out.println("\tResult identical to WHATWG rules");
@@ -136,7 +143,7 @@ public class CLI {
         try {
             System.out.println("Parsing with RFC 2396 rules...");
             settings = settings.withStandard(URLParsingSettings.Standard.RFC_2396);
-            url = URL.parse(settings, input);
+            url = URL.parse(settings, base, input);
             if (rfc3986UrlSerialized.equals(url.toString())) {
                 System.out.println("\tResult identical to RFC 3986 rules");
             } else {


### PR DESCRIPTION
This is just an enhancement request.

Right now the CLI doesn't provide any way to test relative URLs, because it assumes no base URL. It seems like the CLI would be more useful if it just assumed a base URL. The test cases at https://github.com/w3c/web-platform-tests/blob/master/url/urltestdata.txt assume "http://example.org/foo/bar" as a base URL, so I think just matching that would be good.

If you're OK with this idea but you’d prefer to make the base URL a user option that can be set through a command-line switch rather than making it hard-coded the way it is in the PR, then please just let me know—I’d be happy to write up a patch that adds that
