### PR TITLE
Prevent unnecessary Javadoc warning

### DIFF
--- a/src/main/java/io/mola/galimatias/URL.java
+++ b/src/main/java/io/mola/galimatias/URL.java
@@ -568,6 +568,7 @@ public class URL implements Serializable {
         return new URLParser(parseFragment, this, URLParser.ParseURLState.FRAGMENT).parse();
     }
 
+    @SuppressWarnings("javadoc")
     /**
      * Converts to {@link java.net.URI}.
      *


### PR DESCRIPTION
This change causes javadoc warnings for io.mola.galimatias.URL.toJavaURI() to be ignored. Without this change, the `>` characters in the current Javadoc for that method cause the javadoc command to emit “invalid usage of tag” warnings.